### PR TITLE
Update OSXOSImpl and related

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,18 +21,24 @@
 *.app
 
 # Build byproducts
-build
-package.txt
-dist.txt
+/build
+/package.txt
+/package-description.txt
+/dist.txt
 /fahclient
+/fah-client
 /*.pkg
+/*.pkg.zip
+/*.mpkg.zip
+/*.tar.bz2
 
 # generic files to ignore
 *~
 *.lock
-*.DS_Store
+.DS_Store
 *.swp
 *.out
+/tmp
 
 # Backup files
 *~
@@ -42,11 +48,12 @@ dist.txt
 .sconsign.dblite
 config.log
 
+# client testing byproducts
 /config.xml
-/package-description.txt
 /log.txt
 /client.db
 /gpus.json
+/configs
 /logs
 /work
 /cores

--- a/SConstruct
+++ b/SConstruct
@@ -138,6 +138,7 @@ if 'package' in COMMAND_LINE_TARGETS:
 
     AlwaysBuild(pkg)
     env.Alias('package', pkg)
+    Clean(pkg, ['build/pkg', 'package.txt', 'package-description.txt'])
 
     with open('package-description.txt', 'w') as f:
         f.write(short_description.strip())

--- a/install/osx/launchd.plist
+++ b/install/osx/launchd.plist
@@ -2,19 +2,36 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ExitTimeOut</key>
+	<integer>20</integer>
 	<key>GroupName</key>
 	<string>nobody</string>
 	<key>KeepAlive</key>
-	<true/>
+	<false/>
 	<key>Label</key>
 	<string>org.foldingathome.fahclient</string>
+	<key>LaunchEvents</key>
+	<dict>
+		<key>com.apple.notifyd.matching</key>
+		<dict>
+			<key>fahclient on-demand launch request</key>
+			<dict>
+				<key>Notification</key>
+				<string>org.foldingathome.fahclient.nobody.start</string>
+			</dict>
+		</dict>
+	</dict>
 	<key>LowPriorityIO</key>
 	<true/>
+	<key>ProcessType</key>
+	<string>Standard</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/usr/local/bin/FAHClient</string>
+		<string>/usr/local/bin/fah-client</string>
 	</array>
 	<key>RunAtLoad</key>
+	<true/>
+	<key>SessionCreate</key>
 	<true/>
 	<key>StandardOutPath</key>
 	<string>/dev/null</string>

--- a/install/osx/scripts/onquit
+++ b/install/osx/scripts/onquit
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# fah-client-bastet onquit
+
 if [ "$1" != "--delayed-action" ]; then
   "$0" --delayed-action "$@" &
   exit 0

--- a/install/osx/scripts/postinstall
+++ b/install/osx/scripts/postinstall
@@ -1,23 +1,6 @@
 #!/bin/bash -e
-#
-# Scripts: preinstall, preupgrade, postflight, postupgrade, postinstall
-#
-# Arguments passed by installer:
-#   $1: full path to the installation package
-#   $2: full path to the installation destination
-#   $3: mountpoint of the destination volume
-#   $4: root directory "/" for the current System folder
-#
-# Environment variables available to a postflight executable:
-#   $INSTALLER_TEMP: scratch area used by Installer for temporary work file
-#   $PACKAGE_PATH: full path to the installation package; should be same as $1
-#   $RECEIPT_PATH: full path to directory containing the file being executed
-#   $SCRIPT_NAME: name of the file being executed
-#   $TMPDIR: if set, a path to a location on a writable destination volume
-#
-# $PACKAGE_PATH is not available in preflight
-# $RECEIPT_PATH is not available in preflight or preinstall
-# $SCRIPT_NAME is not available in preflight or preinstall
+
+# fah-client-bastet postinstall
 
 # Setup run directory
 RUN_DIR="/Library/Application Support/FAHClient"
@@ -27,25 +10,17 @@ chown -R nobody:nobody "$RUN_DIR"
 
 PLIST=/Library/LaunchDaemons/org.foldingathome.fahclient.plist
 
-# Apply #1103 workaround if OSX 10.9+
-PLISTBUDDY=/usr/libexec/PlistBuddy
-OS_MAJOR="`sw_vers -productVersion | cut -f2 -d.`"
-if [ "$OS_MAJOR" -ge 12 ]; then
-  # OSX 10.12+
-  $PLISTBUDDY -c "Add :ProcessType string 'Interactive'" "$PLIST"
-  $PLISTBUDDY -c "Add :SessionCreate bool true" "$PLIST"
-elif [ "$OS_MAJOR" -ge 9 ]; then
-  # OSX 10.9 thru 10.11
-  $PLISTBUDDY -c "Add :ProgramArguments: string '--respawn'" "$PLIST"
-fi
-
 # remove old client and wrapper
-[ -f /usr/bin/FAHClient ] && rm -f /usr/bin/FAHClient
-[ -f /usr/bin/FAHCoreWrapper ] && rm -f /usr/bin/FAHCoreWrapper
+# SIP may prevent this
+[ -f /usr/bin/FAHClient ] && rm -f /usr/bin/FAHClient || true
+[ -f /usr/bin/FAHCoreWrapper ] && rm -f /usr/bin/FAHCoreWrapper || true
 
 # Start service
 chmod 0644 "$PLIST"
 launchctl load -w "$PLIST"
+
+# start, in case RunAtLoad is false
+launchctl start org.foldingathome.fahclient || true
 
 # Don't launch GUI if CLI install
 [ "$COMMAND_LINE_INSTALL" == "1" ] && exit 0

--- a/install/osx/scripts/preinstall
+++ b/install/osx/scripts/preinstall
@@ -1,23 +1,6 @@
 #!/bin/bash -e
-#
-# Scripts: preinstall, preupgrade, postflight, postupgrade, postinstall
-#
-# Arguments passed by installer:
-#   $1: full path to the installation package
-#   $2: full path to the installation destination
-#   $3: mountpoint of the destination volume
-#   $4: root directory "/" for the current System folder
-#
-# Environment variables available to a postflight executable:
-#   $INSTALLER_TEMP: scratch area used by Installer for temporary work file
-#   $PACKAGE_PATH: full path to the installation package; should be same as $1
-#   $RECEIPT_PATH: full path to directory containing the file being executed
-#   $SCRIPT_NAME: name of the file being executed
-#   $TMPDIR: if set, a path to a location on a writable destination volume
-#
-# $PACKAGE_PATH is not available in preflight
-# $RECEIPT_PATH is not available in preflight or preinstall
-# $SCRIPT_NAME is not available in preflight or preinstall
+
+# fah-client-bastet preinstall
 
 # Unload any launchd jobs
 OLD_LAUNCHD="/Library/LaunchDaemons/FAHClient.plist"
@@ -46,10 +29,5 @@ fi
 # even though it will be overwritten, move so any Dock alias might still work
 F1="/Applications/FAHClient.url"
 F2="/Applications/Folding@home/Web Control.url"
-if [ -f "$F1" ]; then
-  if [ -f "$F2" ]; then
-    rm -f "$F1"
-  else
-    mv "$F1" "$F2"
-  fi
-fi
+[ -f "$F1" ] && rm -f "$F1" || true
+[ -f "$F2" ] && rm -f "$F2" || true

--- a/src/fah/client/App.cpp
+++ b/src/fah/client/App.cpp
@@ -315,12 +315,18 @@ void App::run() {
     SystemUtilities::openURI("https://console.foldingathome.org/");
 
   // Event loop
-  base.dispatch();
+  os->dispatch();
 
   LOG_INFO(1, "Clean exit");
 }
 
 
 void App::signalEvent(Event::Event &e, int signal, unsigned flags) {
+  requestExit();
+}
+
+
+void App::requestExit() {
+  Application::requestExit();
   base.loopExit();
 }

--- a/src/fah/client/App.h
+++ b/src/fah/client/App.h
@@ -126,6 +126,7 @@ namespace FAH {
 
       // From cb::Application
       void run();
+      void requestExit();
 
       void signalEvent(cb::Event::Event &e, int signal, unsigned flags);
     };

--- a/src/fah/client/OS.cpp
+++ b/src/fah/client/OS.cpp
@@ -59,6 +59,7 @@ SmartPointer<OS> OS::create(App &app) {
 
 void OS::requestExit() {app.requestExit();}
 
+void OS::dispatch() {app.getEventBase().dispatch();}
 
 void OS::setOnIdle(bool onIdle) {}
 bool OS::getOnIdle() const {return false;}

--- a/src/fah/client/OS.h
+++ b/src/fah/client/OS.h
@@ -47,6 +47,7 @@ namespace FAH {
       App &getApp() {return app;}
 
       virtual bool isSystemIdle() const = 0;
+      virtual void dispatch();
 
       void requestExit();
 

--- a/src/fah/client/osx/OSXOSImpl.h
+++ b/src/fah/client/osx/OSXOSImpl.h
@@ -45,7 +45,7 @@ namespace FAH {
       static OSXOSImpl *singleton;
 
       bool systemIsIdle = false;
-      bool screensaverIsActive false;
+      bool screensaverIsActive = false;
       bool screenIsLocked = false;
       bool loginwindowIsActive = false;
 
@@ -58,6 +58,7 @@ namespace FAH {
       CFRunLoopSourceRef consoleUserRLS = 0;
       CFStringRef consoleUser = 0;
 
+      CFRunLoopRef threadRunLoop = 0;
       CFRunLoopTimerRef updateTimer = 0;
 
       int idleDelay = 5;
@@ -69,15 +70,15 @@ namespace FAH {
       OSXOSImpl(App &app);
       ~OSXOSImpl();
 
-      OSXOSImpl &instance() {return *singleton;}
-
-      void init();
+      static OSXOSImpl &instance();
 
       // From OS
       bool isSystemIdle() const {return systemIsIdle;}
+      void dispatch();
 
       // From cb::Thread
       void run();
+      void stop();
 
       // Callbacks
       void consoleUserChanged
@@ -88,8 +89,13 @@ namespace FAH {
       void updateTimerFired(CFRunLoopTimerRef timer, void *info);
 
     protected:
+      void init();
+      void initialize();
+      void addHeartbeatTimerToRunLoop(CFRunLoopRef loop);
       bool registerForConsoleUserNotifications();
+      bool registerForDarwinNotifications();
       bool registerForDisplayPowerNotifications();
+      bool registerForLaunchEvents();
       void updateSystemIdle();
       void delayedUpdateSystemIdle(int delay = -1);
       void displayDidDim();


### PR DESCRIPTION
Update OSXOSImpl
- fix compile errors
- support launchd.plist LaunchEvents
- support darwin notifications
- integrate CFRunLoop with libevent loop

Update launchd.plist
- add ExitTimeOut 20
- add LaunchEvents
- set KeepAlive false
- set ProcessType Standard
- set SessionCreate true

Update osx scripts

Update OS
- add virtual OS::dispatch()

Update App
- add requestExit()
- use OS::dispatch()