### PR TITLE
Simplify OSXOSImpl::dispatch()

### DIFF
--- a/src/fah/client/osx/OSXOSImpl.h
+++ b/src/fah/client/osx/OSXOSImpl.h
@@ -58,7 +58,6 @@ namespace FAH {
       CFRunLoopSourceRef consoleUserRLS = 0;
       CFStringRef consoleUser = 0;
 
-      CFRunLoopRef threadRunLoop = 0;
       CFRunLoopTimerRef updateTimer = 0;
 
       int idleDelay = 5;
@@ -90,7 +89,6 @@ namespace FAH {
       void updateTimerFired(CFRunLoopTimerRef timer, void *info);
 
     protected:
-      void init();
       void initialize();
       void addHeartbeatTimerToRunLoop(CFRunLoopRef loop);
       bool registerForConsoleUserNotifications();


### PR DESCRIPTION
Able to greatly simplify, because lifetime of cb::Thread subthread is limited to dispatch().

Old long-lived subthread was previously doing no work anyway.
So now it runs the event_base loop.
