### PR TITLE
Enable idle folding

### DIFF
--- a/src/fah/client/App.cpp
+++ b/src/fah/client/App.cpp
@@ -301,8 +301,8 @@ void App::run() {
 
 
 void App::requestExit() {
-  getUnits().shutdown([this]() {base.loopExit();});
   Application::requestExit();
+  getUnits().shutdown([this]() {base.loopExit();});
 }
 
 

--- a/src/fah/client/Unit.cpp
+++ b/src/fah/client/Unit.cpp
@@ -166,10 +166,10 @@ void Unit::setPause(bool pause) {insertBoolean("paused", pause);}
 
 const char *Unit::getPauseReason() const {
   if (app.getConfig().getPaused()) return "Paused by user";
-  if (getBoolean("paused", true))  return "Resources not available";
   if (app.shouldQuit())            return "Shutting down";
   if (isWaiting())                 return "Waiting to retry";
   if (isIdling())                  return "Waiting for idle system";
+  if (getBoolean("paused", true))  return "Resources not available";
   return "Not paused";
 }
 

--- a/src/fah/client/Units.cpp
+++ b/src/fah/client/Units.cpp
@@ -142,10 +142,10 @@ void Units::update() {
     return;
   }
 
-  // No further action if paused or idle
+  // No further action if paused. Check later if waiting for idle
   auto &config = app.getConfig();
   if (config.getPaused()) return;
-  if (config.getOnIdle() && !app.getOS().isSystemIdle()) return;
+  if (config.getOnIdle() && !app.getOS().isSystemIdle()) return event->add(5);
 
   // Wait on failures
   auto now = Time::now();
@@ -190,6 +190,12 @@ void Units::update() {
   }
 
   lastWU = Time::now();
+
+  // If we were waiting for idle, trigger just unit updates so they may unpause
+  // Do not use triggerUpdate(), which would cause a loop with this method
+  if (config.getOnIdle())
+    for (unsigned i = 0; i < size(); i++)
+      get(i).cast<Unit>()->triggerNext();
 }
 
 


### PR DESCRIPTION
Enable idle folding

On launch, don't show "Resources not available" for units that are actually "Waiting for idle"

Call Application::requestExit() before shutting down units, which need app.shouldQuit() for graceful shutdown