### PR TITLE
Don't try to load CUDA on osx

### DIFF
--- a/src/fah/client/GPUResources.cpp
+++ b/src/fah/client/GPUResources.cpp
@@ -151,7 +151,9 @@ void GPUResources::detect() {
   }
 
   // Match with detected devices
+#ifndef __APPLE__
   match<CUDALibrary>(*this, "cuda");
+#endif
   match<OpenCLLibrary>(*this, "opencl");
 
   LOG_INFO(3, "gpus = " << *this);


### PR DESCRIPTION
CUDA is not supported anymore on macOS.
Even if you have an old CUDA framework installed, the client can't load it and logs an exception:

04:14:39:E :Exception: Failed to open dynamic library '/Library/Frameworks/CUDA.framework/CUDA': dlopen(/Library/Frameworks/CUDA.framework/CUDA, 1): no suitable image found.  Did find:
04:14:39:E :	/Library/Frameworks/CUDA.framework/CUDA: code signature in (/Library/Frameworks/CUDA.framework/CUDA) not valid for use in process using Library Validation: mapping process and mapped file (non-platform) have different Team IDs
04:14:39:E :       At: src/cbang/os/DynamicLibrary.cpp:85:cb::DynamicLibrary::DynamicLibrary()
04:14:39:E :Caught at: src/fah/client/GPUResources.cpp:68
