### PR TITLE
Use Localizable.strings

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -106,7 +106,7 @@ if 'package' in COMMAND_LINE_TARGETS:
                 # name is component pkg file name and name shown in installer
                 'name'        : 'FAHClient',
                 'pkg_id'      : 'org.foldingathome.fahclient.pkg',
-                'description' : short_description,
+                'description' : 'FAH_CLIENT_DESC', # Localizable.strings key
                 # abs path or relative to PWD
                 # client repo directory
                 'home'        : client_home,
@@ -190,7 +190,4 @@ if 'package' in COMMAND_LINE_TARGETS:
     AlwaysBuild(pkg)
     env.Alias('package', pkg)
     Clean(pkg, ['build/pkg', 'build/flatdistpkg', 'package-description.txt'])
-    NoClean(pkg, [Glob('*.zip'), 'package.txt'])
-
-    with open('package-description.txt', 'w') as f:
-        f.write(short_description.strip())
+    NoClean(pkg, [Glob('*.pkg'), 'package.txt'])

--- a/install/osx/Resources/en.lproj/Localizable.strings
+++ b/install/osx/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+"FAH_CLIENT_DESC" = "Folding@home client software which downloads and runs Folding@home simulation work units.
+
+Finished work units are returned to the Folding@home servers for points.
+
+Fold on your own or in a team.  Compete with folders around the world to earn the most points while contributing to science.
+
+Monitor and control the client via your browser by visiting
+https://app.foldingathome.org/";

--- a/package.json
+++ b/package.json
@@ -4,5 +4,5 @@
   "bin": {
     "fah-client": "./fah-client"
   },
-  "description": "Folding@home client software which downloads and runs Folding@home simulation work units.\\n\\nFinished work units are returned to the Folding@home servers for points.\\n\\nFold on your own or in a team.  Compete with folders around the world to earn the most points while contributing to science.\\n\\nMonitor and control the client via your browser by visiting\\nhttps://app.foldingathome.org/"
+  "description": "Folding@home client software which downloads and runs Folding@home simulation work units.\n\nFinished work units are returned to the Folding@home servers for points.\n\nFold on your own or in a team.  Compete with folders around the world to earn the most points while contributing to science.\n\nMonitor and control the client via your browser by visiting\nhttps://app.foldingathome.org/"
 }


### PR DESCRIPTION
Use Localizable.strings for pkg description
Don't overwrite package-description.txt
Update NoClean list
Remove excessive escaping in package.json

This requires PR https://github.com/CauldronDevelopmentLLC/cbang/pull/109