### PR TITLE
Set first-run paused true, unless config.xml has paused false

### DIFF
--- a/src/fah/client/App.cpp
+++ b/src/fah/client/App.cpp
@@ -135,6 +135,7 @@ App::App() :
   options.pushCategory("Resource Settings");
   options.add("cpus", "Number of cpus FAH client will use.",
               new MaxConstraint<int32_t>(SystemInfo::instance().getCPUCount()));
+  options.add("paused", "True if paused on first-run.")->setDefault(true);
   options.popCategory();
 
   // Configure log

--- a/src/fah/client/Config.cpp
+++ b/src/fah/client/Config.cpp
@@ -70,6 +70,8 @@ Config::Config(App &app, const JSON::ValuePtr &config) : app(app) {
       default:                   insert(key, options[key]);             break;
       }
 
+  insertBoolean("paused", options["paused"].toBoolean());
+
   // Load config data
   merge(*config);
 }


### PR DESCRIPTION
BROKEN - DO NOT MERGE

Closes #32
Even with the new title, the ticket its about first-run paused.

This is important to me.
If you ask the alpha testers, I think the overwhelming majority want first-run paused true.
I've seen three in favor of paused, none in favor of folding starting without user clicking start. And one who disparaged the old `fold-anon` mechanism.
