### PR TITLE
Use ProcessType Interactive for osx service

### DIFF
--- a/install/osx/launchd.plist
+++ b/install/osx/launchd.plist
@@ -27,7 +27,7 @@
 	<key>LowPriorityIO</key>
 	<true/>
 	<key>ProcessType</key>
-	<string>Standard</string>
+	<string>Interactive</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/usr/local/bin/fah-client</string>


### PR DESCRIPTION
This appears to be needed for macOS 13.3+ to more reliably avoid e-cores on Apple silicon.

Higher priority processes can still push folding onto e-cores.