### PR TITLE
Organize new credit logs

### DIFF
--- a/src/fah/client/Unit.cpp
+++ b/src/fah/client/Unit.cpp
@@ -1082,8 +1082,9 @@ void Unit::uploadResponse(const JSON::ValuePtr &data) {
 
   // Log credit record
   try {
-    SystemUtilities::ensureDirectory("credits");
-    data->write(*SystemUtilities::oopen("credits/" + getID() + ".json"));
+    string dir = Time().toString("credits/%Y/%m/");
+    SystemUtilities::ensureDirectory(dir);
+    data->write(*SystemUtilities::oopen(dir + getID() + ".json"));
   } CATCH_ERROR;
 }
 


### PR DESCRIPTION
This is for #59.

Not addressed is need to organize existing `credits/*.json`.
I already have over 3000.

I don't know if this code uses local time or UTC.
Don't think it matters much.
