### PR TITLE
RPM: BuildRequires: systemd-rpm-macros

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -204,8 +204,7 @@ if 'package' in COMMAND_LINE_TARGETS:
         rpm_preun          = 'build/install/rpm/preun',
         rpm_conflicts      = 'FAHClient, fahclient',
         rpm_obsoletes      = 'FAHClient, fahclient',
-        # In RHEL >= 8 and Fedora, BuildRequires: systemd-rpm-macros
-        rpm_build_requires = 'systemd',
+        rpm_build_requires = 'systemd-rpm-macros',
         rpm_pre_requires   = 'systemd, shadow-utils',
         rpm_post_requires  = 'systemd, coreutils',
         rpm_preun_requires = 'systemd',

--- a/SConstruct
+++ b/SConstruct
@@ -196,7 +196,6 @@ if 'package' in COMMAND_LINE_TARGETS:
 
         rpm_license        = env['PACKAGE_LICENSE'],
         rpm_group          = 'Applications/Internet',
-        rpm_build          = 'build/install/rpm/build',
         rpm_install        = 'build/install/rpm/install',
         rpm_post           = 'build/install/rpm/post',
         rpm_postun         = 'build/install/rpm/postun',

--- a/install/rpm/build
+++ b/install/rpm/build
@@ -1,1 +1,0 @@
-# rpmbuild requeries %%build and %%install sections present to auto strip binaries


### PR DESCRIPTION
CentOS 7 compiler is too old, lacks required C++14 support.