### PR TITLE
DEB/RPM: only enable/start on initial install

### DIFF
--- a/install/debian/postinst.in
+++ b/install/debian/postinst.in
@@ -36,10 +36,21 @@ elif [ -f $CLIENT_HOME/config.xml ]; then
   echo "Warning: $CLIENT_HOME/config.xml ignored, using $CLIENT_CONFIG/config.xml"
 fi
 
-# Start the service
-systemctl daemon-reload
-systemctl -q enable $NAME
-systemctl start $NAME
+systemctl daemon-reload || true
+
+# only enable/start on initial install
+if [ -z "$2" ]; then
+  systemctl -q enable $NAME || true
+  systemctl start $NAME || true
+else
+  # upgrade
+  # reenable if fixing broken symlink
+  if dpkg --compare-versions "$2" lt 8.2.1; then
+    systemctl -q enable $NAME || true
+  fi
+
+  systemctl try-restart $NAME || true
+fi
 
 echo
 echo "The Folding@home client is now installed"

--- a/install/debian/postrm
+++ b/install/debian/postrm
@@ -4,7 +4,7 @@ NAME=fah-client
 
 case "$1" in
   remove)
-    systemctl daemon-reload
+    systemctl daemon-reload || true
     ;;
 
   purge)

--- a/install/debian/preinst
+++ b/install/debian/preinst
@@ -11,18 +11,19 @@ case "$1" in
     fi
     # Create group if it does not exist
     if ! getent group $NAME >/dev/null; then
-      groupadd --force --system $NAME
+      groupadd --system $NAME || true
     fi
     # Create user if it does not exist
     if ! getent passwd $NAME >/dev/null; then
       useradd --system --gid $NAME --shell /usr/sbin/nologin \
-        --home-dir $CLIENT_HOME --no-create-home --groups video,render $NAME
+        --home-dir $CLIENT_HOME --no-create-home --groups video,render $NAME || true
     fi
     ;;
 
   upgrade)
-    systemctl stop $NAME || true
-    # remove old, possibly outdated service symlink
-    systemctl -q disable $NAME || true
+    # remove broken symlink installed by previous v8 packages
+    if dpkg --compare-versions "$2" lt 8.2.1; then
+      systemctl -q disable $NAME || true
+    fi
     ;;
 esac

--- a/install/rpm/post.in
+++ b/install/rpm/post.in
@@ -17,8 +17,11 @@ fi
 
 %%systemd_post fah-client.service
 # the above macro uses systemctl preset, based on distribution policy to enable units
-systemctl -q enable fah-client.service
-systemctl start fah-client.service
+# only enable/start on initial install
+if [ $1 -eq 1 ]; then
+  systemctl -q enable fah-client.service || true
+  systemctl start fah-client.service || true
+fi
 
 echo
 echo "The Folding@home client is now installed"


### PR DESCRIPTION
Closes FoldingAtHome/fah-client-bastet#160

I added some `|| true` juice while at it.