### PR TITLE
OSX: organize credits in background on install

### DIFF
--- a/install/osx/scripts/postinstall
+++ b/install/osx/scripts/postinstall
@@ -12,7 +12,7 @@ chown -R nobody:nobody "$RUN_DIR"
 
 PLIST=/Library/LaunchDaemons/org.foldingathome.fahclient.plist
 
-"$SCRIPTS"/organize-credits.sh || true
+"$SCRIPTS"/organize-credits.sh &
 
 # Start service
 chmod 0644 "$PLIST"


### PR DESCRIPTION
Organize credits in background on install.
Some may have thousands of files.
Script moves less than 100/sec on SSD.