### PR TITLE
Return os name "win64" on Win x64

### DIFF
--- a/src/fah/client/win/WinOSImpl.cpp
+++ b/src/fah/client/win/WinOSImpl.cpp
@@ -203,7 +203,13 @@ void WinOSImpl::init() {
 }
 
 
-const char *WinOSImpl::getName() const {return "win32";}
+const char *WinOSImpl::getName() const {
+#ifdef _WIN64
+  return "win64";
+#else
+  return "win32";
+#endif
+}
 
 
 const char *WinOSImpl::getCPU() const {


### PR DESCRIPTION
This is assuming all servers can handle both "win32" and "win64".
