### PR TITLE
RPM: remove install/rpm/install

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -196,7 +196,6 @@ if 'package' in COMMAND_LINE_TARGETS:
 
         rpm_license        = env['PACKAGE_LICENSE'],
         rpm_group          = 'Applications/Internet',
-        rpm_install        = 'build/install/rpm/install',
         rpm_post           = 'build/install/rpm/post',
         rpm_postun         = 'build/install/rpm/postun',
         rpm_pre            = 'build/install/rpm/pre',

--- a/install/rpm/install
+++ b/install/rpm/install
@@ -1,1 +1,0 @@
-cp -a . $RPM_BUILD_ROOT


### PR DESCRIPTION
This is done by default in cbang now.