### PR TITLE
Add polkit rule to allow sleep inhibition on Linux

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -180,6 +180,8 @@ if 'package' in COMMAND_LINE_TARGETS:
         desktop_menu       = ['build/install/lin/fah-client.desktop'],
         changelog          = 'CHANGELOG.md',
         systemd            = ['build/install/lin/fah-client.service'],
+        misc               = [['build/install/lin/fah-client.pkla',
+                               'var/lib/polkit-1/localauthority/10-vendor.d/fah-client.pkla']],
 
         nsi                = 'build/install/win/fah-client.nsi',
         timestamp_url      = 'http://timestamp.comodoca.com/authenticode',

--- a/install/lin/fah-client.pkla
+++ b/install/lin/fah-client.pkla
@@ -1,0 +1,4 @@
+[Allow fah-client to inhibit sleep]
+Identity=unix-user:fah-client
+Action=org.freedesktop.login1.inhibit-block-sleep
+ResultAny=yes


### PR DESCRIPTION
See:

https://github.com/CauldronDevelopmentLLC/cbang/commit/d3fe192eb995aeb821b5640400669e4827ad04a7

By default, logind policy does not allow unprivileged processes outside the user session to set up inhibitors. We can change that with a custom rule. There are two formats: INI (`.pkla`, only format supported up to polkit 0.105) and JavaScript (`.rules`, starting with 0.106). Each one uses different paths too. Version 0.106 is from 2012, but Debian stayed in version 0.105 up to Bullseye (11). Compatibility with the old format in 0.106+ does exist, requiring separate packages (Debian's `polkitd-pkla` and Fedora/RHEL's `polkit-pkla-compat`):

https://www.debian.org/releases/bookworm/amd64/release-notes/ch-information.en.html#changes-to-polkit-configuration

The equivalent JavaScript rule is:

```
polkit.addRule(function(action, subject) {
    if (action.id == "org.freedesktop.login1.inhibit-block-sleep" &&
        subject.user == "fah-client") {
            return polkit.Result.YES;
    }
});
```

Installed as `/usr/share/polkit-1/rules.d/fah-client.rules`.