### PR TITLE
DEB: remove libc6 from deb_depends

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -188,7 +188,7 @@ if 'package' in COMMAND_LINE_TARGETS:
 
         deb_directory      = 'build/install/debian',
         deb_section        = 'science',
-        deb_depends        = 'libc6, ca-certificates',
+        deb_depends        = 'ca-certificates',
         deb_conflicts      = 'FAHClient, fahclient',
         deb_replaces       = 'FAHClient, fahclient',
         deb_pre_depends    = 'adduser',


### PR DESCRIPTION
Library dependencies are added by cbang now.