### PR TITLE
osx: Rename web control url file and add icon

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -110,12 +110,19 @@ if 'package' in COMMAND_LINE_TARGETS:
     pkg_target = None
     pkg_components = []
     if env['PLATFORM'] == 'darwin':
+        def seticon(info):
+            """Add icon to web control url file resourse fork"""
+            # brew install fileicon
+            # Packager functions do not preserve rsrc fork, so use callback
+            env.RunCommand(['fileicon', 'set',
+                info['root'] + '/Applications/Folding@home/Folding@home.url',
+                'images/fahlogo.icns'])
         # Specify components for the osx distribution pkg
         client_home = '.'
         client_root = client_home + '/build/pkg/root'
         pkg_files = [[str(client[0]), 'usr/local/bin/', 0o755],
                      ['build/install/osx/fahclient.url',
-                      'Applications/Folding@home/fahclient.url', 0o644],
+                      'Applications/Folding@home/Folding@home.url', 0o644],
                      ['build/install/osx/uninstall.url',
                       'Applications/Folding@home/uninstall.url', 0o644],
                      ['build/install/osx/launchd.plist',
@@ -144,6 +151,7 @@ if 'package' in COMMAND_LINE_TARGETS:
                     'edu.stanford.folding.fahcontrol',
                     ],
                 'pkg_files'   : pkg_files,
+                'pre_sign_callback' : seticon,
             },
         ]
         # min pkg target macos 10.13

--- a/install/osx/scripts/preinstall
+++ b/install/osx/scripts/preinstall
@@ -28,10 +28,12 @@ F1="/Applications/FAHClient.url"
 F2="/Applications/Folding@home/Web Control.url"
 F3="/Library/Application Support/FAHClient/GPUs.txt"
 F4="/Applications/Folding@home/Uninstall Folding@home.pkg"
+F5="/Applications/Folding@home/fahclient.url"
 [ -f "$F1" ] && rm -f "$F1" || true
 [ -f "$F2" ] && rm -f "$F2" || true
 [ -f "$F3" ] && rm -f "$F3" || true
 [ -f "$F4" ] && rm -f "$F4" || true
+[ -f "$F5" ] && rm -f "$F5" || true
 A1="/Applications/Folding@home/FAHControl.app"
 A2="/Applications/Folding@home/FAHViewer.app"
 [ -d "$A1" ] && rm -rf "$A1" || true


### PR DESCRIPTION
This is ready to merge.
`fileicon` has been installed on buildbot worker.
This needs https://github.com/CauldronDevelopmentLLC/cbang/pull/147