### PR TITLE
Add RPM build instructions

### DIFF
--- a/BUILDING-RPM.md
+++ b/BUILDING-RPM.md
@@ -1,0 +1,48 @@
+# Building the RPM package
+
+## Install the Prerequisites
+
+### Fedora/Red Hat Enterprise Linux (RHEL)
+```
+sudo dnf -y install git python3-scons gcc-c++ openssl-devel zlib-devel bzip2-devel systemd-devel rpm-build systemd-rpm-macros
+```
+
+On Red Hat Enterprise Linux (RHEL) 8 and clones, you need to first enable the PowerTools repository with `sudo dnf config-manager --set-enabled powertools`. On RHEL 9 and clones, enable the [EPEL repository](https://docs.fedoraproject.org/en-US/epel/) instead.
+
+### openSUSE
+```
+sudo zypper -n in git scons gcc-c++ libopenssl-devel zlib-devel libbz2-devel systemd-devel rpm-build systemd-rpm-macros
+```
+
+## Get the code
+```
+git clone https://github.com/cauldrondevelopmentllc/cbang
+git clone https://github.com/foldingathome/fah-client-bastet
+```
+
+## Build the Folding@home Client
+```
+export CBANG_HOME=$PWD/cbang
+scons -C cbang
+scons -C fah-client-bastet
+scons -C fah-client-bastet package
+```
+
+(on RHEL 8 and clones, replace `scons` with `scons-3`)
+
+## Install the package
+The last build step builds the RPM package. You can then install it like this:
+
+### Fedora/Red Hat Enterprise Linux (RHEL)
+```
+sudo dnf install ./fah-client-bastet/fah_client-<version>-1.x86_64.rpm
+```
+
+### openSUSE
+```
+sudo zypper in ./fah-client-bastet/fah_client-<version>-1.x86_64.rpm
+```
+
+Where `<version>` is the software version number. On openSUSE, ignore ("i") when `zypper` complains the package is not signed.
+
+Folding@home Client older than v8 will be automatically removed.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ development purposes.
 
 # Quick Start for Debian Linux
 
+(see the [BUILDING-RPM.md](BUILDING-RPM.md) file for instructions on how to build the RPM package)
+
 ## Install the Prerequisites
 ```
 sudo apt update
-sudo apt install -y scons git npm build-essential libssl-dev libsystemd-dev
+sudo apt install -y scons git npm build-essential libssl-dev zlib1g-dev libbz2-dev libsystemd-dev
 ```
 
 ## Get the code
@@ -58,15 +60,15 @@ scons -C fah-client-bastet package
 ```
 
 ## Install the package
-The last build step builds the Debian package.  Before installing this package
-it is recommend that you first uninstall any previous Folding@home client
-software.  You can then install the package like this:
+The last build step builds the Debian package.  You can then install it like this:
 
 ```
 sudo apt install ./fah-client-bastet/fah-client_<version>_amd64.deb
 ```
 
 Where ``<version>`` is the software version number.
+
+Folding@home Client older than v8 will be automatically removed.
 
 ## Folding@home Client Service
 After installation, the service runs and will automatically restart on startup.


### PR DESCRIPTION
Differences from https://github.com/FoldingAtHome/fah-client-bastet/issues/153#issuecomment-1764926549:

- Since https://github.com/FoldingAtHome/fah-client-bastet/commit/2ca272ee0e3a586d58e3fee684f26639aebad072 we do not need `libstdc++-static` anymore on Fedora/RHEL.
- I added `zlib-devel` and `bzip2-devel` (`libbz2-devel` on openSUSE) in the prerequisites, as commented in https://github.com/FoldingAtHome/fah-client-bastet/discussions/182#discussioncomment-8470199.

I think we should add `zlib1g-dev` and `libbz2-dev` to the DEB instructions too... what do you think?

@kbernhagen