### PR TITLE
Fix RPM build on openSUSE Tumbleweed

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -197,6 +197,7 @@ if 'package' in COMMAND_LINE_TARGETS:
         rpm_conflicts      = 'FAHClient, fahclient',
         rpm_obsoletes      = 'FAHClient, fahclient',
         rpm_build_requires = 'systemd-rpm-macros',
+        rpm_provides       = 'user(fah-client), group(fah-client)',
         rpm_requires       = 'polkit',
         rpm_pre_requires   = 'systemd, (shadow-utils or shadow)',
         rpm_post_requires  = 'systemd, coreutils',


### PR DESCRIPTION
Required since RPM 4.19. Fedora disables this feature (for now):

https://src.fedoraproject.org/rpms/rpm/blob/f40/f/rpm-4.18.90-weak-user-group.patch