### PR TITLE
Order Linux systemd service after nss-lookup.target

### DIFF
--- a/install/lin/fah-client.service
+++ b/install/lin/fah-client.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Folding@home Client
-After=network.target
+After=network.target nss-lookup.target
 
 [Service]
 User=fah-client


### PR DESCRIPTION
Ensures caching services like systemd-resolved or dnsmasq start first.