### PR TITLE
Disable NoNewPrivileges

### DIFF
--- a/install/lin/fah-client.service
+++ b/install/lin/fah-client.service
@@ -10,7 +10,7 @@ Restart=always
 StandardOutput=null
 KillMode=mixed
 PrivateTmp=yes
-NoNewPrivileges=yes
+# NoNewPrivileges=yes
 ProtectSystem=full
 ProtectHome=yes
 


### PR DESCRIPTION
Temporary workaround for nvidia cards disabled after reboot

This may be a widespread problem.

PR made at request of @marcosfrm 

> Nvidia is dependent on a SUID binary for this. Disabling NoNewPrivileges= will significantly compromise the service process's sandboxing, but we might not have any other options. I'm away from my work PC for a few days. Could you please comment out the NoNewPrivileges= line for me (INI-style comment, #, default is disabled)? It would be cool to mention in the commit that ideally we could add it back someday when the Nvidia driver is less *** in that regard.

Relevant forum threads:

https://foldingforum.org/viewtopic.php?t=40515

https://foldingforum.org/viewtopic.php?t=41945
