### PR TITLE
macOS: Run service client with app policies

### DIFF
--- a/install/osx/launchd.plist
+++ b/install/osx/launchd.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>ExitTimeOut</key>
-	<integer>20</integer>
+	<integer>30</integer>
 	<key>GroupName</key>
 	<string>nobody</string>
 	<key>KeepAlive</key>

--- a/install/osx/scripts/postinstall
+++ b/install/osx/scripts/postinstall
@@ -14,6 +14,14 @@ PLIST=/Library/LaunchDaemons/org.foldingathome.fahclient.plist
 
 "$SCRIPTS"/organize-credits.sh &
 
+OS_MAJOR="`sw_vers -productVersion | cut -f1 -d.`"
+if [ "$OS_MAJOR" -ge 15 ]; then
+  /usr/libexec/PlistBuddy -c \
+    "Add :ProgramArguments:0 string '/usr/sbin/taskpolicy'" $PLIST
+  /usr/libexec/PlistBuddy -c \
+    "Add :ProgramArguments:1 string '-a'" $PLIST
+fi
+
 # Start service
 chmod 0644 "$PLIST"
 launchctl load -w "$PLIST"


### PR DESCRIPTION
Workaround for slow folding on macOS 15.2 if High Performance mode is not selected (when available)
Seems harmless on earlier macOS releases, but only patch macOS 15+

Increase ExitTimeOut to 30 seconds

PR tested ok on macOS 15.2 and 10.14.6
