### PR TITLE
Enable auto-vacuum and vacuum sqlite database at exit

### DIFF
--- a/src/fah/client/App.cpp
+++ b/src/fah/client/App.cpp
@@ -497,6 +497,7 @@ void App::run() {
   db.open("client.db");
   db.execute("PRAGMA locking_mode=EXCLUSIVE");
   db.execute("PRAGMA synchronous=NORMAL");
+  db.execute("PRAGMA auto_vacuum=FULL");
 
   // Check that we have AS
   if (options["assignment-servers"].toStrings().empty())
@@ -516,6 +517,10 @@ void App::run() {
 
   // Event loop
   os->dispatch();
+
+  // Reduce database size
+  LOG_INFO(3, "Vacuuming database");
+  db.execute("VACUUM");
 
   // Dealocate
   clear();


### PR DESCRIPTION
The sqlite database can get very large if it is not periodically [vacuumed](https://sqlite.org/lang_vacuum.html). Vacuuming it at exit and enabling auto-vacuum reduces database size significantly.

Fixes https://github.com/FoldingAtHome/fah-client-bastet/issues/123