### PR TITLE
Set service stop timeout to 60 seconds

### DIFF
--- a/install/lin/fah-client.service
+++ b/install/lin/fah-client.service
@@ -9,6 +9,7 @@ WorkingDirectory=/var/lib/fah-client
 Restart=always
 StandardOutput=null
 KillMode=mixed
+TimeoutStopSec=60
 PrivateTmp=yes
 # NoNewPrivileges=yes
 ProtectSystem=full


### PR DESCRIPTION
Although the default is usually higher, some distros and users configure their default service stop timeout to be much lower. If the service is stopped and this much time passes before the client exits, it is killed forcefully. Setting the stop timeout explicitly is good practice and prevents users from losing WUs if the default timeout is low.