### PR TITLE
Expose client and core PIDs and client CWD over the WebSocket API

### DIFF
--- a/src/fah/client/App.cpp
+++ b/src/fah/client/App.cpp
@@ -428,6 +428,8 @@ void App::loadConfig() {
   try {
     d->insert("hostname",  sysInfo.getHostname());
   } CATCH_WARNING;
+  d->insert("pid",         SystemUtilities::getPID());
+  d->insert("cwd",         SystemUtilities::getcwd());
 
   Info &info = Info::instance();
   d->insert("mode",               info.get(getName(), "Mode"));

--- a/src/fah/client/Unit.cpp
+++ b/src/fah/client/Unit.cpp
@@ -480,17 +480,20 @@ void Unit::next() {
 
 
 void Unit::processStarted(const SmartPointer<CoreProcess> &process) {
-  LOG_INFO(3, "Started FahCore on PID " << process->getPID());
+  auto pid = process->getPID();
+  LOG_INFO(3, "Started FahCore on PID " << pid);
   this->process = process;
   lastSkewTimer = processStartTime = Time::now();
   lastKnownDone = lastKnownTotal = lastKnownProgressUpdate = clockSkew = 0;
   insert("start_time", Time(processStartTime).toString());
+  insert("pid", pid);
 }
 
 
 void Unit::processEnded() {
   insert("run_time", getRunTime());
   erase("start_time");
+  erase("pid");
   processStartTime = 0;
 }
 


### PR DESCRIPTION
Exposing the PID and CWD of the client makes it easier to identify the
client over the WebSocket API. Exposing the PID of the running cores
makes monitoring performance statistics easier. This is important for
third-party applications which connect to the WebSocket API and need to
be able to find and read the cores' data files.