### PR TITLE
Increase socket timeout to 5 minutes

### DIFF
--- a/src/fah/client/App.cpp
+++ b/src/fah/client/App.cpp
@@ -189,8 +189,8 @@ App::App() :
   (sigtermEvent = base.newSignal(SIGTERM, this, &App::signalEvent))->add();
 
   // Network timeout
-  client.setReadTimeout(60);
-  client.setWriteTimeout(60);
+  client.setReadTimeout(300);
+  client.setWriteTimeout(300);
 
   // Ignore SIGPIPE & SIGHUP
 #ifndef _WIN32


### PR DESCRIPTION
Because of the way cbang buffers uploads, the socket timeout will expire if 60 seconds have passed since the last upload progress update, even if data is still being uploaded. On slow connections, this can cause finished WUs to build up, each new WU slowing down the upload and increasing the chance of an inappropriate timeout (https://github.com/FoldingAtHome/fah-client-bastet/issues/98). This can also cause mild issues with database consistency (https://github.com/FoldingAtHome/fah-client-bastet/issues/352). Increasing the socket timeout from 1 minute to 5 minutes helps significantly.

This should prevent the problem reported in https://github.com/FoldingAtHome/fah-client-bastet/issues/317, although not by supporting upload resumption.

This does _not_ fix a related bug where the timeout never expires (https://github.com/FoldingAtHome/fah-client-bastet/issues/355) when establishing the connection.