### PR TITLE
Add option to limit concurrent uploads

### DIFF
--- a/src/fah/client/App.cpp
+++ b/src/fah/client/App.cpp
@@ -131,6 +131,8 @@ App::App() :
   options.add("web-root", "Path to files to be served by the client's Web "
               "server")->setDefault("fah-web-control/dist");
   options.add("on-idle", "Folding only when idle.")->setDefault(false);
+  options.add("max-uploads", "Maximum concurrent uploads per resource group",
+              new MinMaxConstraint<int32_t>(0, 99))->setDefault(3);
   options.popCategory();
 
   // Note these options are available but hidden in non-debug builds

--- a/src/fah/client/Group.cpp
+++ b/src/fah/client/Group.cpp
@@ -277,7 +277,8 @@ void Group::update() {
     return;
 
   // Add new WU if we don't already have too many and there are some resources
-  const unsigned maxWUs = config->getGPUs().size() + config->getCPUs() / 64 + 3;
+  const unsigned maxWUs = config->getGPUs().size() + config->getCPUs() / 64 +
+    app.getOptions()["max-uploads"].toInteger();
   if (wuCount < maxWUs && (remainingCPUs || remainingGPUs.size())) {
     SmartPointer<Unit> unit =
       new Unit(app, name, app.getNextWUID(), remainingCPUs, remainingGPUs);


### PR DESCRIPTION
Add a configuration option, `max-uploads`, to limit the maximum number of concurrent uploads. The default remains 3. A resource group will download a new WU only when the number of pending uploads falls below this value.

Fixes #98