### PR TITLE
Order fah-client.service after systemd-logind.service

### DIFF
--- a/install/lin/fah-client.service
+++ b/install/lin/fah-client.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Folding@home Client
-After=network.target nss-lookup.target
+After=network.target nss-lookup.target systemd-logind.service
+Wants=systemd-logind.service
 
 [Service]
 User=fah-client


### PR DESCRIPTION
When compiled with systemd support, fah-client communicates with logind to obtain the idle state and prevent the system from sleeping. Hence, add the ordering.