### PR TITLE
Poll udev to wait for the GPU driver to load

### DIFF
--- a/src/fah/client/lin/LinOSImpl.h
+++ b/src/fah/client/lin/LinOSImpl.h
@@ -32,21 +32,12 @@
 
 #include <cbang/config.h>
 
-#ifdef HAVE_SYSTEMD
-#include <systemd/sd-bus.h>
-#endif
-
 
 namespace FAH {
   namespace Client {
     class LinOSImpl : public OS {
-#ifdef HAVE_SYSTEMD
-    sd_bus *bus = 0;
-#endif
-
     public:
-      LinOSImpl(App &app);
-      ~LinOSImpl();
+      LinOSImpl(App &app) : OS(app) {}
 
       // From OS
       const char *getName()      const override;


### PR DESCRIPTION
Monitoring logind's CanGraphical property for seat0 is insufficient. For this property to be true, only the udev tag "master-of-seat" is required on a device. The generic simpledrm driver meets this condition very early, exposing a primary node (/dev/dri/cardN), usually within the initramfs stage.

However, fah-client requires a functional render node (/dev/dri/renderDN). This device only appears once the specialized GPU driver is fully loaded and successfully replaces simpledrm.

Therefore, we use sd-device to continuously poll for the appearance of at least one render node.