### PR TITLE
Include what origin is being denied in CORS check fail message

### DIFF
--- a/src/fah/client/Server.cpp
+++ b/src/fah/client/Server.cpp
@@ -89,7 +89,7 @@ bool Server::corsCB(HTTP::Request &req) {
   if (req.inHas("Origin")) {
     string origin = req.inGet("Origin");
 
-    if (!allowed(origin)) THROWX("Access denied by Origin", HTTP_UNAUTHORIZED);
+    if (!allowed(origin)) THROWX("Access denied by Origin: " << origin, HTTP_UNAUTHORIZED);
 
     req.outSet("Access-Control-Allow-Origin", origin);
     req.outSet("Access-Control-Allow-Methods", "POST,PUT,GET,OPTIONS,DELETE");


### PR DESCRIPTION
The current error message just says some origin is being denied, not which, and there's nothing else in the log that indicates what the origin is. Not exactly helpful for tinkering with \<allowed-origin-exprs>.