### PR TITLE
RPM: remove BuildRequires

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -189,7 +189,6 @@ if 'package' in COMMAND_LINE_TARGETS:
         rpm_obsoletes      = 'FAHClient, fahclient',
         rpm_suggests       = 'python3-websocket-client',
         rpm_provides       = 'user(fah-client), group(fah-client)',
-        rpm_build_requires = 'systemd-rpm-macros',
         rpm_requires       = 'polkit, expat',
         rpm_pre_requires   = 'systemd, procps, (shadow-utils or shadow)',
         rpm_post_requires  = 'systemd, coreutils',


### PR DESCRIPTION
`BuildRequires: systemd-rpm-macros` was added as a safety net to avoid producing a broken RPM if the user hadn't installed the macros. However, when building the package on Debian, rpmbuild can fail because it can't resolve BuildRequires. Since we already document that systemd-rpm-macros is required on Fedora/RHEL/openSUSE, remove the BuildRequires entry to allow building the RPM on Debian by manually downloading the systemd macros, for example (v239):

sudo apt install -y rpm
curl -Ls https://github.com/systemd/systemd/raw/refs/tags/v239/src/core/macros.systemd.in | \
  sudo install -m644 /dev/stdin /usr/lib/rpm/macros.d/macros.systemd
...
scons -C fah-client-bastet package package_type=rpm