### PR TITLE
Remove bz2 from PREFER_DYNAMIC

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -51,7 +51,7 @@ if not env.GetOption('clean'):
             flags = ['-Wl,--wrap=' + x for x in funcs.split()]
             env.AppendUnique(LINKFLAGS = flags)
 
-        env.Append(PREFER_DYNAMIC = 'z bz2 lz4 systemd m'.split())
+        env.Append(PREFER_DYNAMIC = 'z lz4 systemd m'.split())
 
 conf.Finish()
 


### PR DESCRIPTION
The SONAME of libbz2 differs between Debian and Red Hat based distributions (.1.0 vs .1). For mostly_static=1 builds, it's preferable to use static libbz2 because of this.