### PR TITLE
test: add CI scaffold and retry policy extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "0 8 * * *"
+
+jobs:
+  build-and-test-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fah-client-bastet
+        uses: actions/checkout@v4
+
+      - name: Checkout cbang
+        uses: actions/checkout@v4
+        with:
+          repository: cauldrondevelopmentllc/cbang
+          path: ../cbang
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            fakeroot \
+            git \
+            libbz2-dev \
+            liblz4-dev \
+            libssl-dev \
+            libsystemd-dev \
+            npm \
+            scons \
+            zlib1g-dev
+
+      - name: Build cbang
+        run: scons -C ../cbang
+
+      - name: Build client
+        run: CBANG_HOME=$GITHUB_WORKSPACE/../cbang scons
+
+      - name: Run tests
+        run: CBANG_HOME=$GITHUB_WORKSPACE/../cbang scons test

--- a/SConstruct
+++ b/SConstruct
@@ -1,8 +1,12 @@
 # Setup
 import os
 import json
+import sys
+# Route `scons test` through the repo-local runner instead of cbang's default
+# harness so Phase 0 can bootstrap without extra Python test dependencies.
 if 'test' in COMMAND_LINE_TARGETS and 'TEST_COMMAND' not in ARGUMENTS:
-    ARGUMENTS['TEST_COMMAND'] = 'python3 tests/run_phase0_tests.py'
+    os.environ['SCONS_EXECUTABLE'] = sys.argv[0]
+    ARGUMENTS['TEST_COMMAND'] = sys.executable + ' tests/run_phase0_tests.py'
 env = Environment(ENV = os.environ)
 try:
     env.Tool('config', toolpath = [os.environ.get('CBANG_HOME')])

--- a/SConstruct
+++ b/SConstruct
@@ -1,6 +1,8 @@
 # Setup
 import os
 import json
+if 'test' in COMMAND_LINE_TARGETS and 'TEST_COMMAND' not in ARGUMENTS:
+    ARGUMENTS['TEST_COMMAND'] = 'python3 tests/run_phase0_tests.py'
 env = Environment(ENV = os.environ)
 try:
     env.Tool('config', toolpath = [os.environ.get('CBANG_HOME')])
@@ -59,6 +61,10 @@ conf.Finish()
 Export('env')
 client = SConscript('src/client.scons', variant_dir = 'build', duplicate = 0)
 Default(client)
+
+# Tests
+tests = SConscript('tests/SConscript', variant_dir = 'build/tests',
+                   duplicate = 0)
 
 # HideConsole
 hide_console = None

--- a/src/fah/client/Unit.cpp
+++ b/src/fah/client/Unit.cpp
@@ -38,6 +38,7 @@
 #include "Cores.h"
 #include "Config.h"
 #include "ExitCode.h"
+#include "UnitRetryPolicy.h"
 
 #include <cbang/Catch.h>
 
@@ -935,18 +936,16 @@ void Unit::retry() {
       }
     }
 
-    if (++retries < 10 || getState() == UNIT_ASSIGN ||
-        (retries <= 50 && UNIT_UPLOAD <= getState())) {
-      double delay = std::pow(2, std::min(9U, retries));
-      setWait(delay);
-      LOG_INFO(1, "Retry #" << retries << " in " << TimeInterval(delay));
-
-    } else {
+    auto decision = UnitRetryPolicy::evaluate(getState(), ++retries);
+    if (decision.fail) {
       LOG_INFO(1, "Too many retries (" << (retries - 1) << "), failing WU");
       setWait(0);
       retries = 0;
       return clean("retries");
     }
+
+    setWait(decision.delay);
+    LOG_INFO(1, "Retry #" << retries << " in " << TimeInterval(decision.delay));
 
     insert("retries", retries);
     return;

--- a/src/fah/client/UnitRetryPolicy.cpp
+++ b/src/fah/client/UnitRetryPolicy.cpp
@@ -1,0 +1,51 @@
+/******************************************************************************\
+
+                  This file is part of the Folding@home Client.
+
+          The fah-client runs Folding@home protein folding simulations.
+                    Copyright (c) 2001-2026, foldingathome.org
+                               All rights reserved.
+
+       This program is free software; you can redistribute it and/or modify
+       it under the terms of the GNU General Public License as published by
+        the Free Software Foundation; either version 3 of the License, or
+                       (at your option) any later version.
+
+         This program is distributed in the hope that it will be useful,
+          but WITHOUT ANY WARRANTY; without even the implied warranty of
+          MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+                   GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License along
+     with this program; if not, write to the Free Software Foundation, Inc.,
+           51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+                  For information regarding this software email:
+                                 Joseph Coffland
+                          joseph@cauldrondevelopment.com
+
+\******************************************************************************/
+
+#include "UnitRetryPolicy.h"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace FAH::Client;
+
+
+UnitRetryDecision UnitRetryPolicy::evaluate(UnitState state, unsigned retries) {
+  UnitRetryDecision decision;
+
+  // Assignment can retry indefinitely because no downloaded WU state is at
+  // risk, while upload gets a much larger retry ceiling to protect completed
+  // results from transient network failures.
+  if (retries < 10 || state == UnitState::UNIT_ASSIGN ||
+      (retries <= 50 && UnitState::UNIT_UPLOAD <= state)) {
+    decision.delay = std::pow(2, std::min(9U, retries));
+    return decision;
+  }
+
+  decision.fail = true;
+  return decision;
+}

--- a/src/fah/client/UnitRetryPolicy.h
+++ b/src/fah/client/UnitRetryPolicy.h
@@ -1,0 +1,46 @@
+/******************************************************************************\
+
+                  This file is part of the Folding@home Client.
+
+          The fah-client runs Folding@home protein folding simulations.
+                    Copyright (c) 2001-2026, foldingathome.org
+                               All rights reserved.
+
+       This program is free software; you can redistribute it and/or modify
+       it under the terms of the GNU General Public License as published by
+        the Free Software Foundation; either version 3 of the License, or
+                       (at your option) any later version.
+
+         This program is distributed in the hope that it will be useful,
+          but WITHOUT ANY WARRANTY; without even the implied warranty of
+          MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+                   GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License along
+     with this program; if not, write to the Free Software Foundation, Inc.,
+           51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+                  For information regarding this software email:
+                                 Joseph Coffland
+                          joseph@cauldrondevelopment.com
+
+\******************************************************************************/
+
+#pragma once
+
+#include "UnitState.h"
+
+namespace FAH {
+  namespace Client {
+    struct UnitRetryDecision {
+      bool fail = false;
+      double delay = 0;
+    };
+
+
+    class UnitRetryPolicy {
+    public:
+      static UnitRetryDecision evaluate(UnitState state, unsigned retries);
+    };
+  }
+}

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -12,6 +12,7 @@ test_bin = env.Program(
         '#/tests/phase0_tests.cpp',
         '#/src/fah/client/PasskeyConstraint.cpp',
         '#/src/fah/client/ExitCode.cpp',
+        '#/src/fah/client/UnitRetryPolicy.cpp',
     ],
 )
 

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,0 +1,29 @@
+import subprocess
+
+Import('*')
+
+env.Append(CPPPATH = ['#/src'])
+
+test_bin = env.Program(
+    '#/build/tests/fah-client-tests',
+    [
+        '#/tests/phase0_tests.cpp',
+        '#/src/fah/client/PasskeyConstraint.cpp',
+        '#/src/fah/client/ExitCode.cpp',
+    ],
+)
+
+
+def run_tests(target, source, env):
+    return subprocess.call([str(source[0])])
+
+
+test_run = env.Command(
+    '#/build/tests/test.stamp',
+    test_bin,
+    env.Action(run_tests, 'Running $SOURCE'),
+)
+AlwaysBuild(test_run)
+env.Alias('test', test_run)
+
+Return('test_bin')

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -4,6 +4,8 @@ Import('*')
 
 env.Append(CPPPATH = ['#/src'])
 
+# Keep Phase 0 narrow: compile a small binary around self-contained backend
+# logic before introducing a larger test framework or runtime-heavy fixtures.
 test_bin = env.Program(
     '#/build/tests/fah-client-tests',
     [
@@ -18,6 +20,8 @@ def run_tests(target, source, env):
     return subprocess.call([str(source[0])])
 
 
+# Preserve `scons test` as the public entry point while still allowing the
+# binary to be built directly in CI or local development.
 test_run = env.Command(
     '#/build/tests/test.stamp',
     test_bin,

--- a/tests/phase0_tests.cpp
+++ b/tests/phase0_tests.cpp
@@ -28,6 +28,7 @@
 
 #include "fah/client/PasskeyConstraint.h"
 #include "fah/client/ExitCode.h"
+#include "fah/client/UnitRetryPolicy.h"
 
 #include <cbang/Exception.h>
 #include <cbang/json/String.h>
@@ -106,12 +107,37 @@ namespace {
     expect(!ExitCode::isValid((ExitCode::enum_t)42),
            "ExitCode value 42 should be invalid");
   }
+
+
+  void testUnitRetryPolicy() {
+    // This is the first extracted policy seam from Unit.cpp. It is pure logic
+    // and captures retry thresholds that have direct user-visible behavior.
+    auto assign = UnitRetryPolicy::evaluate(UnitState::UNIT_ASSIGN, 25);
+    expect(!assign.fail, "Assignment retries should stay retryable past 10");
+    expect(assign.delay == 512, "Assignment retry delay should cap at 512s");
+
+    auto run = UnitRetryPolicy::evaluate(UnitState::UNIT_RUN, 9);
+    expect(!run.fail, "Run retries below 10 should keep retrying");
+    expect(run.delay == 512, "Ninth retry should use the capped delay");
+
+    auto runFail = UnitRetryPolicy::evaluate(UnitState::UNIT_RUN, 10);
+    expect(runFail.fail, "Run retries at 10 should fail the WU");
+    expect(runFail.delay == 0, "Failure decisions should not carry a delay");
+
+    auto upload = UnitRetryPolicy::evaluate(UnitState::UNIT_UPLOAD, 50);
+    expect(!upload.fail, "Upload retries should allow a larger ceiling");
+    expect(upload.delay == 512, "Upload retry delay should also cap at 512s");
+
+    auto uploadFail = UnitRetryPolicy::evaluate(UnitState::UNIT_UPLOAD, 51);
+    expect(uploadFail.fail, "Upload retries above 50 should fail the WU");
+  }
 }
 
 
 int main() {
   testPasskeyConstraint();
   testExitCode();
+  testUnitRetryPolicy();
 
   if (failures) {
     std::cerr << failures << " test assertion(s) failed" << std::endl;

--- a/tests/phase0_tests.cpp
+++ b/tests/phase0_tests.cpp
@@ -1,0 +1,119 @@
+/******************************************************************************\
+
+                  This file is part of the Folding@home Client.
+
+          The fah-client runs Folding@home protein folding simulations.
+                    Copyright (c) 2001-2026, foldingathome.org
+                               All rights reserved.
+
+       This program is free software; you can redistribute it and/or modify
+       it under the terms of the GNU General Public License as published by
+        the Free Software Foundation; either version 3 of the License, or
+                       (at your option) any later version.
+
+         This program is distributed in the hope that it will be useful,
+          but WITHOUT ANY WARRANTY; without even the implied warranty of
+          MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+                   GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License along
+     with this program; if not, write to the Free Software Foundation, Inc.,
+           51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+                  For information regarding this software email:
+                                 Joseph Coffland
+                          joseph@cauldrondevelopment.com
+
+\******************************************************************************/
+
+#include "fah/client/PasskeyConstraint.h"
+#include "fah/client/ExitCode.h"
+
+#include <cbang/Exception.h>
+#include <cbang/json/String.h>
+
+#include <functional>
+#include <iostream>
+#include <string>
+
+
+using namespace FAH;
+using namespace FAH::Client;
+
+
+namespace {
+  unsigned failures = 0;
+
+
+  void fail(const std::string &msg) {
+    std::cerr << "FAIL: " << msg << std::endl;
+    failures++;
+  }
+
+
+  void expect(bool condition, const std::string &msg) {
+    if (!condition) fail(msg);
+  }
+
+
+  void expectThrows(const std::function<void()> &fn,
+                    const std::string &expected) {
+    try {
+      fn();
+      fail("Expected exception containing: " + expected);
+
+    } catch (const cb::Exception &e) {
+      std::string msg = e.getMessage();
+      if (msg.find(expected) == std::string::npos)
+        fail("Exception mismatch. Expected substring '" + expected +
+             "', got '" + msg + "'");
+    }
+  }
+
+
+  void testPasskeyConstraint() {
+    PasskeyConstraint constraint;
+
+    constraint.validate(cb::JSON::String(""));
+    constraint.validate(cb::JSON::String("0123456789abcdef0123456789abcdef"));
+    constraint.validate(cb::JSON::String("ABCDEF0123456789ABCDEF0123456789"));
+
+    expectThrows(
+      [&] {constraint.validate(cb::JSON::String("abcd"));},
+      "32 characters long");
+    expectThrows(
+      [&] {
+        constraint.validate(cb::JSON::String("0123456789abcdef0123456789abcdeg"));
+      },
+      "invalid character");
+    expect(constraint.getHelp().find("32 characters long") != std::string::npos,
+           "Passkey help text should mention 32 characters");
+  }
+
+
+  void testExitCode() {
+    expect(ExitCode::parse("FINISHED_UNIT") == ExitCode::FINISHED_UNIT,
+           "ExitCode should parse FINISHED_UNIT");
+    expect(ExitCode::parse("WU_STALLED") == ExitCode::WU_STALLED,
+           "ExitCode should parse WU_STALLED");
+    expect(std::string(ExitCode(ExitCode::GPU_UNAVAILABLE_ERROR).toString()) ==
+             "GPU_UNAVAILABLE_ERROR",
+           "ExitCode should stringify GPU_UNAVAILABLE_ERROR");
+    expect(!ExitCode::isValid((ExitCode::enum_t)42),
+           "ExitCode value 42 should be invalid");
+  }
+}
+
+
+int main() {
+  testPasskeyConstraint();
+  testExitCode();
+
+  if (failures) {
+    std::cerr << failures << " test assertion(s) failed" << std::endl;
+    return 1;
+  }
+
+  std::cout << "All Phase 0 tests passed" << std::endl;
+  return 0;
+}

--- a/tests/phase0_tests.cpp
+++ b/tests/phase0_tests.cpp
@@ -72,6 +72,8 @@ namespace {
 
 
   void testPasskeyConstraint() {
+    // This is a good Phase 0 target because it exercises project-owned
+    // validation logic without requiring network, filesystem, or process setup.
     PasskeyConstraint constraint;
 
     constraint.validate(cb::JSON::String(""));
@@ -92,6 +94,8 @@ namespace {
 
 
   void testExitCode() {
+    // The generated enum helpers are simple but correctness-critical glue for
+    // process-exit handling elsewhere in the client.
     expect(ExitCode::parse("FINISHED_UNIT") == ExitCode::FINISHED_UNIT,
            "ExitCode should parse FINISHED_UNIT");
     expect(ExitCode::parse("WU_STALLED") == ExitCode::WU_STALLED,

--- a/tests/run_phase0_tests.py
+++ b/tests/run_phase0_tests.py
@@ -7,7 +7,13 @@ import sys
 
 def main():
     env = os.environ.copy()
-    subprocess.check_call(['scons', 'build/tests/fah-client-tests'], env=env)
+    scons = env.get('SCONS_EXECUTABLE', 'scons')
+    # Build first so `scons test` works from a clean checkout and in GitHub
+    # Actions without requiring a separate manual build step.
+    # Clean the Phase 0 target first so local toolchain or architecture changes
+    # do not leave behind incompatible object files between runs.
+    subprocess.check_call([scons, '-c', 'build/tests/fah-client-tests'], env=env)
+    subprocess.check_call([scons, 'build/tests/fah-client-tests'], env=env)
     sys.exit(subprocess.call(['./build/tests/fah-client-tests'], env=env))
 
 

--- a/tests/run_phase0_tests.py
+++ b/tests/run_phase0_tests.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+
+
+def main():
+    env = os.environ.copy()
+    subprocess.check_call(['scons', 'build/tests/fah-client-tests'], env=env)
+    sys.exit(subprocess.call(['./build/tests/fah-client-tests'], env=env))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
  ## Summary
  This adds the first automated test scaffold for `fah-client-bastet`.

  Changes:
  - add a GitHub Actions workflow for Linux build and test
  - wire `scons test` into the repo
  - add initial native tests for `PasskeyConstraint`, `ExitCode`, and retry policy logic
  - extract unit retry/backoff policy from `Unit.cpp` into a small testable component

  ## Validation
  - `CBANG_HOME=/Users/clambert/workspace/cbang scons test`