### PR TITLE
Windows: re-create tray icon when Explorer restarts

### DIFF
--- a/src/fah/client/win/WinOSImpl.cpp
+++ b/src/fah/client/win/WinOSImpl.cpp
@@ -133,6 +133,15 @@ WinOSImpl &WinOSImpl::instance() {
   return *singleton;
 }
 
+void WinOSImpl::recreateTrayIcon() {
+  // Remove possible old icon
+  Shell_NotifyIcon(NIM_DELETE, &notifyIconData);
+
+  // Add it
+  notifyIconData.hWnd = hWnd;
+  if (!Shell_NotifyIcon(NIM_ADD, &notifyIconData))
+    THROW("Failed to register systray icon: " << SysError());
+}
 
 void WinOSImpl::init() {
   // We want to get shutdown before the cores
@@ -186,14 +195,9 @@ void WinOSImpl::init() {
     notifyIconData.guidItem = guid;
     notifyIconData.uFlags |= NIF_GUID;
   }
-
-  // Remove possible old icon
-  Shell_NotifyIcon(NIM_DELETE, &notifyIconData);
-
-  // Add it
-  notifyIconData.hWnd = hWnd;
-  if (!Shell_NotifyIcon(NIM_ADD, &notifyIconData))
-    THROW("Failed to register systray icon: " << SysError());
+  
+  // Create tray icon, removing if pre-existing
+  recreateTrayIcon();
 
   // Register for PM away mode events
   RegisterPowerSettingNotification(
@@ -301,6 +305,15 @@ LRESULT WinOSImpl::windowProc(HWND hWnd, UINT message, WPARAM wParam,
   case WM_TIMER:
     if (wParam == ID_UPDATE_TIMER) updateIcon();
     break;
+
+  default:
+    {
+      // Recreate tray icon if taskbar is re-created
+      const WinOSImpl & winOSImpl = WinOSImpl::instance();
+      if (message == winOSImpl.taskbarCreatedMsg && winOSImpl.systrayEnabled)
+        winOSImpl.recreateTrayIcon();
+      break;
+    }
   }
 
   return DefWindowProc(hWnd, message, wParam, lParam);

--- a/src/fah/client/win/WinOSImpl.h
+++ b/src/fah/client/win/WinOSImpl.h
@@ -62,6 +62,9 @@ namespace FAH {
 
       std::atomic<bool> inAwayMode = false;
       std::atomic<bool> displayOff = false;
+	  
+	  // TaskbarCreated WndProc message, sent when explorer.exe (re)creates taskbar
+	  UINT taskbarCreatedMsg = 0;
 
     public:
       WinOSImpl(App &app);


### PR DESCRIPTION
If Explorer crashes, the Folding@Home tray icon isn't re-created when it is restarted. See the [MS guide](
https://learn.microsoft.com/en-gb/windows/win32/shell/taskbar#taskbar-creation-notification).

I **haven't built this code** as I only see documentation for Debian builds in the README.

Decided not to use a static file-level variable, but that'll probably work too.

Might want to create a `if (systrayEnabled)` check in `recreateTrayIcon()`, then use that in `init()`. Currently `init()` doesn't read `systrayEnabled`, so not sure if it's checked at a different scope or just never read.