### PR TITLE
Improve ARM64 and HIP GPU handling

### DIFF
--- a/src/fah/client/Unit.cpp
+++ b/src/fah/client/Unit.cpp
@@ -101,6 +101,15 @@ namespace {
   }
 
 
+  string getGPUPlatform(const GPUResource &gpu, const Config &config) {
+    if (gpu.isComputeDeviceSupported("cuda",   config)) return "cuda";
+    if (gpu.isComputeDeviceSupported("hip",    config)) return "hip";
+    if (gpu.isComputeDeviceSupported("opencl", config)) return "opencl";
+
+    THROW("GPU has no enabled compute device");
+  }
+
+
   bool existsAndOlderThan(const string &path, unsigned secs) {
     return SystemUtilities::exists(path) &&
       secs < Time::now() - SystemUtilities::getModificationTime(path);
@@ -626,18 +635,17 @@ void Unit::run() {
     }
 
     // GPU platform
-    bool withCUDA = gpu.isComputeDeviceSupported("cuda", getConfig());
-    bool withHIP  = gpu.isComputeDeviceSupported("hip",  getConfig());
+    string gpuPlatform = getGPUPlatform(gpu, getConfig());
     args.push_back("-gpu-platform");
-    args.push_back(withCUDA ? "cuda" : "opencl");
+    args.push_back(gpuPlatform);
 
     // Old GPU options
     args.push_back("-gpu-vendor");
     args.push_back(gpu.getString("type"));
 
     addGPUArgs(args, gpu, "opencl");
-    if (withCUDA) addGPUArgs(args, gpu, "cuda");
-    if (withHIP)  addGPUArgs(args, gpu, "hip");
+    addGPUArgs(args, gpu, "cuda");
+    addGPUArgs(args, gpu, "hip");
 
     if (gpu.has("opencl")) {
       args.push_back("-gpu");

--- a/src/fah/client/lin/LinOSImpl.cpp
+++ b/src/fah/client/lin/LinOSImpl.cpp
@@ -46,7 +46,7 @@ const char *LinOSImpl::getCPU() const {
   string machine(name.machine);
 
   if (machine.find("x86_64") != string::npos) return "amd64";
-  if (machine == "arch64" || machine == "arm64") return "arm64";
+  if (machine == "aarch64" || machine == "arm64") return "arm64";
 
   return OS::getCPU();
 }


### PR DESCRIPTION
## Summary
- recognize Linux `aarch64` as the `arm64` CPU platform
- choose the GPU core platform from supported CUDA, HIP, or OpenCL devices instead of treating every non-CUDA GPU core launch as OpenCL
- continue passing legacy CUDA/HIP/OpenCL GPU arguments when present

## Context
This does not add ARM64 GPU FAHCore binaries or assignment-server support. Those pieces are outside this client repository. The change is limited to client-side platform detection and GPU launch argument selection, which should help avoid incorrect HIP/OpenCL core launch arguments and clean up ARM64 reporting.

## Validation
- `git diff --check`
- `OPENSSL_HOME=/opt/homebrew/opt/openssl@3 PYTHONPATH=/tmp/codex-scons python3 -m SCons -C ../cbang -j2`
- `OPENSSL_HOME=/opt/homebrew/opt/openssl@3 CBANG_HOME="/Users/austondeville/Documents/New project/cbang" PYTHONPATH=/tmp/codex-scons python3 -m SCons -j2`