### PR TITLE
Fix test linking on native Windows builds

### DIFF
--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -20,6 +20,9 @@ if not env.GetOption('clean'):
     conf.CBConfig('cbang')
     env.CBDefine('USING_CBANG')
 
+    # Windows Systray
+    if env['PLATFORM'] == 'win32': conf.CBRequireLib('shell32')
+
 conf.Finish()
 
 # Include the parent source tree and find the libraries built there.


### PR DESCRIPTION
Test are missing reference to shell32 on win32 builds. Fix was to copy the client's win32 shell32 requirement in SConstruct.

Tests fail to link when build on native Windows due to this missing reference.  Link error listed below.  With this fix tests build and pass.  NOTE: `scons -C fah-client-bastet test` does not build the base like it does for cbang.  You have individually call `scons -C fah-client-bastet` before you call the test config.

```
fahclient.lib(WinOSImpl.obj) : error LNK2019: unresolved external symbol __imp_ShellExecuteA referenced in function "protected: void __cdecl FAH::Client::WinOSImpl::openWebControl(void)" (?openWebControl@WinOSImpl@Client@FAH@@IEAAXXZ)
fahclient.lib(WinOSImpl.obj) : error LNK2019: unresolved external symbol __imp_Shell_NotifyIconA referenced in function "protected: void __cdecl FAH::Client::WinOSImpl::loadTrayIcon(void)" (?loadTrayIcon@WinOSImpl@Client@FAH@@IEAAXXZ)
UnitTests\unitLoad.exe : fatal error LNK1120: 2 unresolved externals
```